### PR TITLE
Fix path for running tests

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "autoprefixer": "7.1.2",
     "case-sensitive-paths-webpack-plugin": "2.1.1",
-    "chalk": "1.1.3",
+    "chalk": "2.3.0",
     "css-loader": "0.28.4",
     "dotenv": "4.0.0",
     "extract-text-webpack-plugin": "3.0.0",
@@ -36,21 +36,21 @@
     "postcss-loader": "2.0.6",
     "promise": "8.0.1",
     "react-dev-utils": "^4.0.1",
+    "source-map-loader": "^0.2.1",
     "style-loader": "0.18.2",
+    "sw-precache-webpack-plugin": "0.11.4",
     "ts-jest": "^20.0.7",
     "ts-loader": "^2.3.7",
+    "ts-node": "^3.3.0",
     "tslint": "^5.7.0",
     "tslint-loader": "^3.5.3",
     "tslint-react": "^3.2.0",
     "typescript": "~2.5.3",
-    "source-map-loader": "^0.2.1",
-    "sw-precache-webpack-plugin": "0.11.4",
     "url-loader": "0.5.9",
     "webpack": "3.5.1",
     "webpack-dev-server": "2.7.1",
     "webpack-manifest-plugin": "1.2.1",
-    "whatwg-fetch": "2.0.3",
-    "ts-node": "^3.3.0"
+    "whatwg-fetch": "2.0.3"
   },
   "optionalDependencies": {
     "fsevents": "1.1.2"

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -43,7 +43,7 @@ argv.push(
   JSON.stringify(
     createJestConfig(
       relativePath => path.resolve(__dirname, '..', relativePath),
-      path.resolve(paths.appSrc, '..'),
+      path.resolve(paths.appSrc, '../..'),
       false
     )
   )


### PR DESCRIPTION
The change of the appSrc path from 'src' to 'src/app' causes 'yarn test' to fail to find any tests as resolves the \<rootDir> to the parent of appSrc and then searches in \<rootDir>/src for tests, which resolves to 'src/src', this PR fixes this to take two parents from appSrc.

The bug is easily verified by creating a fresh app using: create-react-app electron-vanilla-app --scripts-version=react-scripts-ts-electron

and running 'yarn test'

btw, this has been a incredibly useful starter for my Electron/Typescript/React app, thanks for the great work @swengorschewski 